### PR TITLE
add locate fdupes button when fdupes binary is not found in path

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,3 +1,3 @@
 {
-  "flutterSdkVersion": "3.13.0"
+  "flutterSdkVersion": "3.13.9"
 }

--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ Recalculates duplicates by pressing the 'Refresh' button top right.
 
 ## Config location
 
-* MacOS: `~/Library/Preferences/be.shibby.fdupes_gui.plist`
+* MacOS: `~/Library/Preferences/be.shibby.fdupes-gui.plist`
 * Linux: todo

--- a/README.md
+++ b/README.md
@@ -42,3 +42,8 @@ The following actions can be performed:
 ### Refresh
 
 Recalculates duplicates by pressing the 'Refresh' button top right.
+
+## Config location
+
+* MacOS: `~/Library/Preferences/be.shibby.fdupes_gui.plist`
+* Linux: todo

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A graphical user interface front end for `fdupes` cli program.
 
 Make sure the following prerequisites are met:
 * `fdupes` command is available from `PATH`
+  * When not found, you can still select the `fdupes` binary location manually.
 * Download `fdupes_gui` from [releases](https://github.com/mx1up/fdupes-gui/releases)
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ Recalculates duplicates by pressing the 'Refresh' button top right.
 ## Config location
 
 * MacOS: `~/Library/Preferences/be.shibby.fdupes-gui.plist`
-* Linux: todo
+* Linux: `~/.local/share/be.shibby.fdupes_gui/shared_preferences.json`

--- a/lib/domain/fdupes_bloc.dart
+++ b/lib/domain/fdupes_bloc.dart
@@ -67,8 +67,13 @@ class FdupesBloc extends Bloc<FdupesEvent, FdupesState> {
   }
 
   Future<bool> validFdupesLocation(String path) async {
-    ProcessResult result = await Process.run(path, ['--version']);
-    return result.exitCode == 0 && (result.stdout as String).split(' ')[0] == 'fdupes';
+    try {
+      ProcessResult result = await Process.run(path, ['--version']);
+      return result.exitCode == 0 && (result.stdout as String).split(' ')[0] == 'fdupes';
+    } catch (e) {
+      print(e);
+      return false;
+    }
   }
 
   FutureOr<void> _onDirSelected(FdupesEventDirSelected event, Emitter<FdupesState> emit) async {

--- a/lib/domain/fdupes_event.dart
+++ b/lib/domain/fdupes_event.dart
@@ -8,6 +8,12 @@ class FdupesEventCheckFdupesAvailability extends FdupesEvent {
   FdupesEventCheckFdupesAvailability();
 }
 
+class FdupesEventSelectFdupesLocation extends FdupesEvent {
+  final String fdupesLocation;
+
+  FdupesEventSelectFdupesLocation(this.fdupesLocation);
+}
+
 class FdupesEventDeleteDupeInstance extends FdupesEvent {
   final String filename;
 

--- a/lib/domain/fdupes_state.dart
+++ b/lib/domain/fdupes_state.dart
@@ -21,6 +21,15 @@ class FdupesStateError extends FdupesState {
   List<Object?> get props => [msg];
 }
 
+class FdupesStateFdupesNotFound extends FdupesState {
+  final String? statusMsg;
+
+  FdupesStateFdupesNotFound({this.statusMsg});
+
+  @override
+  List<Object?> get props => [statusMsg];
+}
+
 class FdupesStateLoading extends FdupesState {
   final String? msg;
   final int? progress;

--- a/lib/presentation/dupe_screen.dart
+++ b/lib/presentation/dupe_screen.dart
@@ -18,6 +18,31 @@ class DupeScreen extends StatelessWidget {
             ),
           );
         }
+        if (state is FdupesStateFdupesNotFound) {
+          return Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text('Fdupes binary not found.'),
+                SizedBox(height: 16),
+                ElevatedButton(
+                  onPressed: () => _locateBinary(context),
+                  child: Text('Locate'),
+                ),
+                if (state.statusMsg != null) ...[
+                  SizedBox(height: 16),
+                  Text(
+                    state.statusMsg!,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.error,
+                          fontStyle: FontStyle.italic,
+                        ),
+                  ),
+                ]
+              ],
+            ),
+          );
+        }
         if (state is FdupesStateError) {
           return Center(child: Text(state.msg));
         }
@@ -73,5 +98,15 @@ class DupeScreen extends StatelessWidget {
     if (dir != null) {
       BlocProvider.of<FdupesBloc>(context).add(FdupesEventDirSelected(dir));
     }
+  }
+
+  Future<void> _locateBinary(BuildContext context) async {
+    final fdupesBloc = context.read<FdupesBloc>();
+    final fdupesLocation = await FileSelectorPlatform.instance.openFile(
+      initialDirectory: util.userHome,
+      confirmButtonText: 'Select',
+    );
+    if (fdupesLocation == null) return;
+    fdupesBloc.add(FdupesEventSelectFdupesLocation(fdupesLocation.path));
   }
 }

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -25,11 +25,11 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
-  file_selector_macos: 468fb6b81fac7c0e88d71317f3eec34c3b008ff9
+  file_selector_macos: 54fdab7caa3ac3fc43c9fac4d7d8d231277f8cf2
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
-  url_launcher_macos: d2691c7dd33ed713bf3544850a623080ec693d95
+  shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
+  url_launcher_macos: 5f437abeda8c85500ceb03f5c1938a8c5a705399
 
 PODFILE CHECKSUM: 236401fc2c932af29a9fcf0e97baeeb2d750d367
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.14.3

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = fdupes_gui
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = be.shibby.fdupes_gui
+PRODUCT_BUNDLE_IDENTIFIER = be.shibby.fdupes-gui
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2023 Shibby Entertainment. All rights reserved.

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = fdupes_gui
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.example.fdupesGui
+PRODUCT_BUNDLE_IDENTIFIER = be.shibby.fdupes_gui
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2023 com.example. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2023 Shibby Entertainment. All rights reserved.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: "direct main"
     description:
       name: adaptive_theme
-      sha256: "38b433c0761d9f15017a15c9ff3e15e8905d3e9bad54a489c7939da6bdf782dd"
+      sha256: f4ee609b464e5efc68131d9d15ba9aa1de4e3b5ede64be17781c6e19a52d637d
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1"
+    version: "3.6.0"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0"
   async:
     dependency: transitive
     description:
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: bloc
-      sha256: "3820f15f502372d979121de1f6b97bfcf1630ebff8fe1d52fb2b0bfa49be5b49"
+      sha256: "106842ad6569f0b60297619e9e0b1885c2fb9bf84812935490e6c5275777804e"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.2"
+    version: "8.1.4"
   boolean_selector:
     dependency: transitive
     description:
@@ -49,14 +49,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -77,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "445db18de832dba8d851e287aff8ccf169bed30d2e94243cb54c7d2f1ed2142c"
+      sha256: "2f9d2cbccb76127ba28528cb3ae2c2326a122446a83de5a056aaa3880d3882c5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3+6"
+    version: "0.3.3+7"
   equatable:
     dependency: "direct main"
     description:
@@ -117,26 +109,26 @@ packages:
     dependency: "direct main"
     description:
       name: file_selector
-      sha256: "84eaf3e034d647859167d1f01cfe7b6352488f34c1b4932635012b202014c25b"
+      sha256: "5019692b593455127794d5718304ff1ae15447dea286cdda9f0db2a796a1b828"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.3"
   file_selector_android:
     dependency: transitive
     description:
       name: file_selector_android
-      sha256: b7556052dbcc25ef88f6eba45ab98aa5600382af8dfdabc9d644a93d97b7be7f
+      sha256: "57265ec9591e8fd8508f613544cde6f7d045731f6b09644057e49a4c9c672b7c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0+4"
+    version: "0.5.1+1"
   file_selector_ios:
     dependency: transitive
     description:
       name: file_selector_ios
-      sha256: b3fbdda64aa2e335df6e111f6b0f1bb968402ed81d2dd1fa4274267999aa32c2
+      sha256: b015154e6d9fddbc4d08916794df170b44531798c8dd709a026df162d07ad81d
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1+6"
+    version: "0.5.1+8"
   file_selector_linux:
     dependency: transitive
     description:
@@ -149,18 +141,18 @@ packages:
     dependency: transitive
     description:
       name: file_selector_macos
-      sha256: b15c3da8bd4908b9918111fa486903f5808e388b8d1c559949f584725a6594d6
+      sha256: f42eacb83b318e183b1ae24eead1373ab1334084404c8c16e0354f9a3e55d385
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3+3"
+    version: "0.9.4"
   file_selector_platform_interface:
     dependency: transitive
     description:
       name: file_selector_platform_interface
-      sha256: "0aa47a725c346825a2bd396343ce63ac00bda6eff2fbc43eabe99737dede8262"
+      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "2.6.2"
   file_selector_web:
     dependency: transitive
     description:
@@ -186,10 +178,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_bloc
-      sha256: e74efb89ee6945bcbce74a5b3a5a3376b088e5f21f55c263fc38cbdc6237faae
+      sha256: b594505eac31a0518bdcb4b5b79573b8d9117b193cc80cc12e17d639b10aa27a
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.3"
+    version: "8.1.6"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -284,10 +276,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "94b1e0dd80970c1ce43d5d4e050a9918fce4f4a775e6142424c30a29a363265c"
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   path_provider_windows:
     dependency: transitive
     description:
@@ -300,34 +292,34 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "0a279f0707af40c890e80b1e9df8bb761694c074ba7e1d4ab1bc4b728e200b59"
+      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.4"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: da3fdfeccc4d4ff2da8f8c556704c08f912542c5fb3cf2233ed75372384a034d
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.6"
+    version: "2.1.8"
   process_run:
     dependency: "direct main"
     description:
       name: process_run
-      sha256: "1cb96f835ec02ba1a35af4e6f99f937618023b6d2ffba88f0c0f1041af2e9f12"
+      sha256: "3d5335d17003a7c2fd5148be2d313f5b84244ab2e625162fdd44b4aaa48bea66"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.2"
+    version: "0.13.3+1"
   provider:
     dependency: transitive
     description:
       name: provider
-      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
+      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.5"
+    version: "6.1.2"
   pub_semver:
     dependency: transitive
     description:
@@ -340,10 +332,10 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "81429e4481e1ccfb51ede496e916348668fd0921627779233bd24cc3ff6abd02"
+      sha256: d3bbe5553a986e83980916ded2f0b435ef2e1893dfaa29d5a7a790d0eca12180
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.3"
   shared_preferences_android:
     dependency: transitive
     description:
@@ -356,10 +348,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: "7bf53a9f2d007329ee6f3df7268fd498f8373602f943c975598bbb34649b62a7"
+      sha256: "7708d83064f38060c7b39db12aefe449cb8cdc031d6062280087bc4cdb988f5c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.4"
+    version: "2.3.5"
   shared_preferences_linux:
     dependency: transitive
     description:
@@ -372,10 +364,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: d4ec5fc9ebb2f2e056c617112aa75dcf92fc2e4faaf2ae999caa297473f75d8a
+      sha256: "22e2ecac9419b4246d7c22bfbbda589e3acf5c0351137d87dd2939d984d37c3b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   shared_preferences_web:
     dependency: transitive
     description:
@@ -433,10 +425,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "5fcbd27688af6082f5abd611af56ee575342c30e87541d0245f7ff99faa02c60"
+      sha256: "539ef412b170d65ecdafd780f924e5be3f60032a1128df156adad6c5b373d558"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.0+1"
   term_glyph:
     dependency: transitive
     description:
@@ -465,50 +457,50 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher
-      sha256: b1c9e98774adf8820c96fbc7ae3601231d324a7d5ebd8babe27b6dfac91357ba
+      sha256: c512655380d241a337521703af62d2c122bf7b77a46ff7dd750092aa9433499c
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.1"
+    version: "6.2.4"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "31222ffb0063171b526d3e569079cf1f8b294075ba323443fdc690842bfd4def"
+      sha256: d4ed0711849dd8e33eb2dd69c25db0d0d3fdc37e0a62e629fe32f57a22db2745
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "6.3.0"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "4ac97281cf60e2e8c5cc703b2b28528f9b50c8f7cebc71df6bdf0845f647268a"
+      sha256: "75bb6fe3f60070407704282a2d295630cab232991eb52542b18347a8a941df03"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "6.2.4"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: "9f2d390e096fdbe1e6e6256f97851e51afc2d9c423d3432f1d6a02a8a9a8b9fd"
+      sha256: ab360eb661f8879369acac07b6bb3ff09d9471155357da8443fd5d3cf7363811
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: b7244901ea3cf489c5335bdacda07264a6e960b1c1b1a9f91e4bc371d9e68234
+      sha256: "9a1a42d5d2d95400c795b2914c36fdcb525870c752569438e4ebb09a2b5d90de"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.2.0"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
-      sha256: "980e8d9af422f477be6948bdfb68df8433be71f5743a188968b0c1b887807e50"
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.2"
   url_launcher_web:
     dependency: transitive
     description:
@@ -521,10 +513,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "7754a1ad30ee896b265f8d14078b0513a4dba28d358eabb9d5f339886f4a1adc"
+      sha256: ecf9725510600aa2bb6d7ddabe16357691b6d2805f66216a97d1b881e21beff7
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   vector_math:
     dependency: transitive
     description:
@@ -545,18 +537,18 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "350a11abd2d1d97e0cc7a28a81b781c08002aa2864d9e3f192ca0ffa18b06ed3"
+      sha256: b0f37db61ba2f2e9b7a78a1caece0052564d1bc70668156cf3a29d676fe4e574
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.9"
+    version: "5.1.1"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      sha256: "589ada45ba9e39405c198fe34eb0f607cddb2108527e658136120892beac46d2"
+      sha256: faea9dee56b520b55a566385b84f2e8de55e7496104adada9962e0bd11bcff1d
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   yaml:
     dependency: transitive
     description:
@@ -566,5 +558,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0 <4.0.0"
-  flutter: ">=3.13.0"
+  dart: ">=3.1.5 <4.0.0"
+  flutter: ">=3.13.9"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -337,7 +337,7 @@ packages:
     source: hosted
     version: "2.1.4"
   shared_preferences:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences
       sha256: "81429e4481e1ccfb51ede496e916348668fd0921627779233bd24cc3ff6abd02"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: 'none'
 version: 0.2.0+2
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
-  flutter: ">=3.13.0"
+  sdk: ">=3.1.5 <4.0.0"
+  flutter: ">=3.13.9"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   path: ^1.8.3
   adaptive_theme: ^3.4.1
   equatable: ^2.0.5
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
if fdupes is not found in path, a binary can be selected manually. Validation is performed to check whether the binary is fdupes. When validated, the path is stored in the config so the manual selection does not need to be repeated.

fixes #1